### PR TITLE
Updated to deku 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.19.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
 dependencies = [
  "funty",
  "radium",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "dbffa8f8e38810422f320ca457a93cf1cd0056dc9c06c556b867558e0d471463"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -259,23 +259,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "06e172685d94b7b83800e3256a63261537b9d6129e10f21c8e13ddf9dba8c64d"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
+ "strsim 0.10.0",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "f0618ac802792cebd1918ac6042a6ea1eeab92db34b35656afaa577929820788"
 dependencies = [
  "darling_core",
  "quote",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58899e303bf5a70317f3458bcea62f62eb485d8a901e52f72b7fab74a735bef"
+checksum = "b1bd2aab2ebe2a3b81ba141217e0b9b8fbf0657c3adac387c6ca50d9f87f405e"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d4fc5c2c06069f7400c2c639b567b0559e72ce79913f6955365cce52e513e6"
+checksum = "7c2bd21f698ce03deea89717758ce5fad12778faa4dc9526e4c3db3fb6af98c6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "redox_syscall"
@@ -886,9 +886,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"

--- a/blflash/Cargo.toml
+++ b/blflash/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.22"
 indicatif = "0.15.0"
 log = "0.4.11"
 env_logger = "0.8.2"
-deku = "0.9.1"
+deku = "0.10.0"
 byteorder = "1.3.4"
 sha2 = "0.9.2"
 structopt = { version = "0.3.21", features = ["paw"] }

--- a/blflash/src/connection.rs
+++ b/blflash/src/connection.rs
@@ -38,8 +38,10 @@ impl Response for NoResponsePayload {
     }
 }
 
-pub trait Response: DekuContainerRead + Sized {
+pub trait Response: for<'a> DekuContainerRead<'a> + Sized {
     fn from_payload(input: &[u8]) -> Result<Self, DekuError> {
+        // We don't care about the lifetime 'a, as we only check the bit offset,
+        // and don't hold onto the borrow on `input`.
         let (_, r) = DekuContainerRead::from_bytes((input, 0))?;
         Ok(r)
     }

--- a/blflash/src/image/partition.rs
+++ b/blflash/src/image/partition.rs
@@ -33,7 +33,7 @@ pub struct Table {
 pub struct Entry {
     #[deku(bytes = "3")]
     pub r#type: u32,
-    #[deku(writer = "Entry::write_name(name, output)")]
+    #[deku(writer = "Entry::write_name(name, deku::output)")]
     pub name: String,
     pub address0: u32,
     pub address1: u32,


### PR DESCRIPTION
This required passing a lifetime param to DekuContainerRead, but it didn't spread
as we only need to check the bit offset.